### PR TITLE
Dockerfile enhancements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN if [ "$VERSION_STYLESHEET" = "latest" ] ; then \
 RUN if [ "$VERSION_ODD" = "latest" ] ; then \
     VERSION_ODD=$(curl "https://api.github.com/repos/TEIC/TEI/releases/latest" | grep -Po '"tag_name": "P5_Release_\K.*?(?=")'); \   
     fi \
-    && echo "Stylesheet version set to ${VERSION_ODD}" \
+    && echo "ODD version set to ${VERSION_ODD}" \
     # download the required tei odd and stylesheet sources in the image and move them to the respective folders ( ${TEI_SOURCES_HOME})
     && curl -s -L -o /tmp/odd.zip https://github.com/TEIC/TEI/releases/download/P5_Release_${VERSION_ODD}/tei-${VERSION_ODD}.zip \
     && unzip /tmp/odd.zip -d /tmp/odd \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ LABEL org.opencontainers.image.source=https://github.com/teic/teigarage
 
 ARG VERSION_STYLESHEET=latest
 ARG VERSION_ODD=latest
+ARG WEBSERVICE_ARTIFACT=https://nightly.link/TEIC/TEIGarage/workflows/maven/main/artifact.zip
+ARG WEBCLIENT_ARTIFACT=https://nightly.link/TEIC/ege-webclient/workflows/maven/main/artifact.zip
 
 ENV CATALINA_WEBAPPS ${CATALINA_HOME}/webapps
 ENV OFFICE_HOME /usr/lib/libreoffice


### PR DESCRIPTION
this is basically two things:

* trying to slim down image size by adding `--no-install-recommends` to `apt install`
* make artefact URLs available as build arguments so we can eventually build a stable version and a dev version from the same Dockerfile